### PR TITLE
Add AppVeyor CI configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+version: 1.0.{build}-{branch}
+
+branches:
+  except:
+    - gh-pages
+
+image: Visual Studio 2015
+
+init:
+  - git config --global core.autocrlf input
+
+install:
+  - cd ..
+  - git clone https://github.com/iqrfsdk/clibcdc.git
+  - git clone https://github.com/iqrfsdk/clibspi.git
+  - cmd: cd clibcdc
+  - cmd: if "%platform%"=="x86" build32.bat
+  - cmd: if "%platform%"=="x64" build64.bat
+  - cmd: cd ..\clibspi
+  - cmd: if "%platform%"=="x86" build32.bat
+  - cmd: if "%platform%"=="x64" build64.bat
+  - cmd: cd ..\cutils
+
+clone_folder: c:\projects\cutils
+
+platform:
+  - x86
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+build:
+  parallel: true
+  verbosity: normal
+
+build_script:
+  - cmd: if "%platform%"=="x86" build32.bat
+  - cmd: if "%platform%"=="x64" build64.bat

--- a/build32.bat
+++ b/build32.bat
@@ -1,7 +1,7 @@
 set project=cutils
 
 rem //expected build dir structure
-set buildexp=build\\Visual_Studio_12_2013\\x86
+set buildexp=build\\Visual_Studio_14_2015\\x86
 
 set currentdir=%cd%
 set builddir=.\\%buildexp%
@@ -22,7 +22,7 @@ popd
 
 rem //launch cmake to generate build environment
 pushd %builddir%
-cmake -G "Visual Studio 12 2013" -Dclibcdc_DIR:PATH=%clibcdc% -Dclibspi_DIR:PATH=%clibspi% %currentdir%
+cmake -G "Visual Studio 14 2015" -Dclibcdc_DIR:PATH=%clibcdc% -Dclibspi_DIR:PATH=%clibspi% %currentdir%
 popd
 
 rem //build from generated build environment


### PR DESCRIPTION
Turn on [AppVeyor](https://ci.appveyor.com/) before you merge this pull request.

AppVeyor is Windows-based CI tool. Build status of my fork is [there](https://ci.appveyor.com/project/Roman3349/cutils).

Signed-off-by: Roman3349 ondracek.roman@centrum.cz